### PR TITLE
Update install to handle arm64 & x64 versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -30,7 +30,19 @@ install_plugin() {
 }
 
 get_platform() {
-  [ "Linux" = "$(uname)" ] && echo "linux" || echo "macosx-x64"
+  if [ "$(uname)" = "Linux" ]; then
+    if [ "$(uname -m)" = "aarch64" ]; then
+      echo "linux-aarch64"
+    else
+      echo "linux-x64"
+    fi
+  else
+    if [ "$(uname -m)" = "arm64" ]; then
+      echo "macosx-aarch64"
+    else
+      echo "macosx-x64"
+    fi
+  fi
 }
 
 get_download_url() {

--- a/bin/install
+++ b/bin/install
@@ -30,7 +30,7 @@ install_plugin() {
 }
 
 get_platform() {
-  [ "Linux" = "$(uname)" ] && echo "linux" || echo "macosx"
+  [ "Linux" = "$(uname)" ] && echo "linux" || echo "macosx-x64"
 }
 
 get_download_url() {


### PR DESCRIPTION
Sonarscanner [has recently updated their binaries](https://binaries.sonarsource.com/?prefix=Distribution/sonar-scanner-cli/) for macOS to support `-x64` and `aarch64` so the script breaks for us as part of our Xcode Cloud workflow.

I have updated the script and have an override version as part of our mise install working for our local arm macs and on Xcode Cloud.