### PR TITLE
fix: Check version to set correct binary platform suffix name

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,3 +25,19 @@ jobs:
           command: sonar-scanner -v
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: asdf_plugin_test_6_0_0_4432
+        uses: asdf-vm/actions/plugin-test@v1.0.1
+        with:
+          command: sonar-scanner --help
+          version: 6.0.0.4432
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: asdf_plugin_test_6_1_0_4477
+        uses: asdf-vm/actions/plugin-test@v1.0.1
+        with:
+          command: sonar-scanner --help
+          version: 6.1.0.4477
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/install
+++ b/bin/install
@@ -29,23 +29,36 @@ install_plugin() {
   rm -rf $tmp_download > /dev/null
 }
 
+semVer() {
+  printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' ');
+}
+
 get_platform() {
   local version=$1
-  if [ "$(uname)" = "Linux" ]; then
-    if [[ "$version" < "6.1.0.4477" ]]; then
-      echo "linux"
-    elif [ "$(uname -m)" = "aarch64" ]; then
+  local breakingVersion="6.1.0.4477"
+
+  case $(uname) in
+    #Linux OS
+    Linux)
+      if [[ $(semVer $version) -lt $(semVer $breakingVersion) ]]; then
+        echo "linux"
+      elif [ "$(uname -m)" = "aarch64" ]; then
         echo "linux-aarch64"
       else
         echo "linux-x64"
-    fi
-  elif [[ "$version" < "6.1.0.4477" ]]; then
-      echo "macosx"
-    elif [ "$(uname -m)" = "arm64" ]; then
+      fi
+    ;;
+    #Mac OS
+    Darwin)
+      if [[ "$version" < "6.1.0.4477" ]]; then
+        echo "macosx"
+      elif [ "$(uname -m)" = "arm64" ]; then
         echo "macosx-aarch64"
       else
         echo "macosx-x64"
-  fi
+      fi
+    ;;
+  esac
 }
 
 get_download_url() {

--- a/bin/install
+++ b/bin/install
@@ -31,17 +31,19 @@ install_plugin() {
 
 get_platform() {
   if [ "$(uname)" = "Linux" ]; then
-    if [ "$(uname -m)" = "aarch64" ]; then
-      echo "linux-aarch64"
-    else
-      echo "linux-x64"
+    if [[ "$version" < "6.1.0.4477" ]]; then
+      echo "linux"
+    elif [ "$(uname -m)" = "aarch64" ]; then
+        echo "linux-aarch64"
+      else
+        echo "linux-x64"
     fi
-  else
-    if [ "$(uname -m)" = "arm64" ]; then
-      echo "macosx-aarch64"
-    else
-      echo "macosx-x64"
-    fi
+  elif [[ "$version" < "6.1.0.4477" ]]; then
+      echo "macosx"
+    elif [ "$(uname -m)" = "arm64" ]; then
+        echo "macosx-aarch64"
+      else
+        echo "macosx-x64"
   fi
 }
 

--- a/bin/install
+++ b/bin/install
@@ -50,7 +50,7 @@ get_platform() {
     ;;
     #Mac OS
     Darwin)
-      if [[ "$version" < "6.1.0.4477" ]]; then
+      if [[ $(semVer $version) -lt $(semVer $breakingVersion) ]]; then
         echo "macosx"
       elif [ "$(uname -m)" = "arm64" ]; then
         echo "macosx-aarch64"

--- a/bin/install
+++ b/bin/install
@@ -20,7 +20,7 @@ install_plugin() {
   curl -L -s "$download_url" -o "download.zip"
   unzip "download.zip" > /dev/null || exit 1
 
-  pushd "sonar-scanner-${version}-$(get_platform)" > /dev/null
+  pushd "sonar-scanner-${version}-$(get_platform $version)" > /dev/null
   cp -r . $install_path
   popd > /dev/null
 
@@ -30,6 +30,7 @@ install_plugin() {
 }
 
 get_platform() {
+  local version=$1
   if [ "$(uname)" = "Linux" ]; then
     if [[ "$version" < "6.1.0.4477" ]]; then
       echo "linux"
@@ -51,7 +52,7 @@ get_download_url() {
   local install_type=$1
   local version=$2
 
-  local platform=$(get_platform)
+  local platform=$(get_platform $version)
   echo "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}-${platform}.zip"
 }
 


### PR DESCRIPTION
Due to recent changes in installation script, backwards compatibility with versions older than the latest one has been broken.
![image](https://github.com/user-attachments/assets/e946bf5b-2355-499f-84dd-b4d65020b632)
It is currently not possible to download older versions of the sonar-scanner-cli binary. Backwards compatibility with older versions must be maintained.
This pull request add the changes to check if the version you are trying to install is older than the change in the naming standard imposed by Sonar on its binaries.
If the version is older than the change, it's used the old suffix. If the version is newer, the architecture is added to the platform as is currently done.
![image](https://github.com/user-attachments/assets/6c2b87f5-d751-4190-aca0-86a708c3fb6e)
![image](https://github.com/user-attachments/assets/449971aa-d725-45bc-8417-5dc644696713)
This allow to download any version of the tool.