### PR TITLE
Fix semver warning

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -40,7 +40,7 @@ get_platform() {
   case $(uname) in
     #Linux OS
     Linux)
-      if [[ $(semVer $version) -lt $(semVer $breakingVersion) ]]; then
+      if [[ "$(semVer $version)" < "$(semVer $breakingVersion)" ]]; then
         echo "linux"
       elif [ "$(uname -m)" = "aarch64" ]; then
         echo "linux-aarch64"
@@ -50,7 +50,7 @@ get_platform() {
     ;;
     #Mac OS
     Darwin)
-      if [[ $(semVer $version) -lt $(semVer $breakingVersion) ]]; then
+      if [[ "$(semVer $version)" < "$(semVer $breakingVersion)" ]]; then
         echo "macosx"
       elif [ "$(uname -m)" = "arm64" ]; then
         echo "macosx-aarch64"


### PR DESCRIPTION
This PR fixes the warning about comparing two versions which are too large numbers. Let's compare them as strings instead.
`bin/install: line 53: [[: 0007000000024839: value too great for base (error token is "0007000000024839")`